### PR TITLE
Parameterized challenger id

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,4 @@
 TWITCH_CHANNEL=codinggarden
 BOT_NAME=bottymcbotface
 BOT_TOKEN=123123123123
+CHALLENGER_ID=w3cj

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ const {
   BOT_TOKEN,
   BOT_NAME,
   TWITCH_CHANNEL,
+  CHALLENGER_ID,
 } = process.env;
 
 const BASE_URL = 'https://lichess.org';
@@ -161,8 +162,7 @@ async function listenChallenges() {
   const challenges = streamUrl(`${BASE_URL}/api/stream/event`);
   challenges.on('event', (event) => {
     if (event.type === 'challenge') {
-      // TODO: parameterize...
-      if (event.challenge.challenger.id === 'w3cj') {
+      if (event.challenge.challenger.id === CHALLENGER_ID) {
         updateChallenge(event);
       } else {
         updateChallenge(event, 'decline');


### PR DESCRIPTION
* Added `CHALLENGER_ID` to `.env.sample`
* Replaced hardcoded `'w3cj'` with `CHALLENGER_ID`